### PR TITLE
Add assert and try-catch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ test {
 
 application {
     mainClass.set("tudee.Launcher")
+    applicationDefaultJvmArgs = ['-ea']
 }
 
 shadowJar {

--- a/data/tudee.txt
+++ b/data/tudee.txt
@@ -4,3 +4,5 @@ T | 0 | join sports club
 D | 1 | return book | 2024-08-29
 T | 0 | play games
 T | 0 | complete analysis
+D | 0 | apply job  | 2024-09-10
+E | 0 | hackathon  | 2024-09-10 | 2024-09-11

--- a/src/main/java/tudee/Tudee.java
+++ b/src/main/java/tudee/Tudee.java
@@ -54,7 +54,7 @@ public class Tudee {
         try {
             Command command = Parser.parse(input);
             return command.execute(taskList, ui, storage);
-        } catch (tudee.TudeeException e) {
+        } catch (TudeeException | AssertionError e) {
             return ui.showError(e.getMessage());
         }
     }

--- a/src/main/java/tudee/command/AddTaskCommand.java
+++ b/src/main/java/tudee/command/AddTaskCommand.java
@@ -32,6 +32,10 @@ public class AddTaskCommand extends Command {
      */
     @Override
     public String execute(TaskList tasks, Ui ui, Storage storage) {
+        // Assert that tasks, ui and storage are not null.
+        assert tasks != null : "TaskList cannot be null";
+        assert ui != null : "Ui cannot be null";
+        assert storage != null : "Storage cannot be null";
         tasks.add(task);
         storage.save(tasks.get());
         return ui.showAdd(task, tasks.size());

--- a/src/main/java/tudee/command/ByeCommand.java
+++ b/src/main/java/tudee/command/ByeCommand.java
@@ -19,6 +19,10 @@ public class ByeCommand extends Command {
      */
     @Override
     public String execute(TaskList tasks, Ui ui, Storage storage) {
+        // Assert that tasks, ui and storage are not null.
+        assert tasks != null : "TaskList cannot be null";
+        assert ui != null : "Ui cannot be null";
+        assert storage != null : "Storage cannot be null";
         return ui.showBye();
     }
 

--- a/src/main/java/tudee/command/DateCommand.java
+++ b/src/main/java/tudee/command/DateCommand.java
@@ -48,6 +48,10 @@ public class DateCommand extends Command {
      */
     @Override
     public String execute(TaskList tasks, Ui ui, Storage storage) throws TudeeException {
+        // Assert that tasks, ui and storage are not null.
+        assert tasks != null : "TaskList cannot be null";
+        assert ui != null : "Ui cannot be null";
+        assert storage != null : "Storage cannot be null";
         boolean haveTask = false;
         TaskList matchingTasks = new TaskList();
         for (Task task : tasks.get()) {

--- a/src/main/java/tudee/command/DeleteCommand.java
+++ b/src/main/java/tudee/command/DeleteCommand.java
@@ -35,6 +35,10 @@ public class DeleteCommand extends Command {
      */
     @Override
     public String execute(TaskList tasks, Ui ui, Storage storage) throws TudeeException {
+        // Assert that tasks, ui and storage are not null.
+        assert tasks != null : "TaskList cannot be null";
+        assert ui != null : "Ui cannot be null";
+        assert storage != null : "Storage cannot be null";
         if (index > tasks.size() || index < 1) {
             throw new TudeeException("You do not have that many tasks!");
         }

--- a/src/main/java/tudee/command/FindCommand.java
+++ b/src/main/java/tudee/command/FindCommand.java
@@ -34,6 +34,10 @@ public class FindCommand extends Command {
      */
     @Override
     public String execute(TaskList tasks, Ui ui, Storage storage) throws TudeeException {
+        // Assert that tasks, ui and storage are not null.
+        assert tasks != null : "TaskList cannot be null";
+        assert ui != null : "Ui cannot be null";
+        assert storage != null : "Storage cannot be null";
         boolean haveKeyword = false;
         TaskList matchingTasks = new TaskList();
         for (Task task: tasks.get()) {

--- a/src/main/java/tudee/command/ListCommand.java
+++ b/src/main/java/tudee/command/ListCommand.java
@@ -20,6 +20,10 @@ public class ListCommand extends Command {
      */
     @Override
     public String execute(TaskList tasks, Ui ui, Storage storage) {
+        // Assert that tasks, ui and storage are not null.
+        assert tasks != null : "TaskList cannot be null";
+        assert ui != null : "Ui cannot be null";
+        assert storage != null : "Storage cannot be null";
         return ui.showTaskList(tasks.get());
     }
 }

--- a/src/main/java/tudee/command/MarkCommand.java
+++ b/src/main/java/tudee/command/MarkCommand.java
@@ -33,6 +33,10 @@ public class MarkCommand extends Command {
      */
     @Override
     public String execute(TaskList tasks, Ui ui, Storage storage) {
+        // Assert that tasks, ui and storage are not null.
+        assert tasks != null : "TaskList cannot be null";
+        assert ui != null : "Ui cannot be null";
+        assert storage != null : "Storage cannot be null";
         Task task = tasks.get(index - 1);
         task.markAsDone();
         storage.save(tasks.get());

--- a/src/main/java/tudee/command/UnknownCommand.java
+++ b/src/main/java/tudee/command/UnknownCommand.java
@@ -19,6 +19,10 @@ public class UnknownCommand extends Command {
      */
     @Override
     public String execute(TaskList tasks, Ui ui, Storage storage) {
+        // Assert that tasks, ui and storage are not null.
+        assert tasks != null : "TaskList cannot be null";
+        assert ui != null : "Ui cannot be null";
+        assert storage != null : "Storage cannot be null";
         return ui.showError("Unknown command! Please try again.");
     }
 }

--- a/src/main/java/tudee/command/UnmarkCommand.java
+++ b/src/main/java/tudee/command/UnmarkCommand.java
@@ -33,6 +33,10 @@ public class UnmarkCommand extends Command {
      */
     @Override
     public String execute(TaskList tasks, Ui ui, Storage storage) {
+        // Assert that tasks, ui and storage are not null.
+        assert tasks != null : "TaskList cannot be null";
+        assert ui != null : "Ui cannot be null";
+        assert storage != null : "Storage cannot be null";
         Task task = tasks.get(index - 1);
         task.markAsNotDone();
         storage.save(tasks.get());

--- a/src/main/java/tudee/parser/Parser.java
+++ b/src/main/java/tudee/parser/Parser.java
@@ -34,25 +34,46 @@ public class Parser {
     public static Command parse(String input) throws TudeeException {
         String[] inputs = input.split(" ", 2);
         String command = inputs[0];
+
+        // Assert that the command part is not empty.
+        assert command != null && !command.isEmpty() : "Input should not be empty";
         if (command.equalsIgnoreCase("list")) {
             return new ListCommand();
         } else if (command.equalsIgnoreCase("bye")) {
             return new ByeCommand();
         } else if (command.equalsIgnoreCase("todo")) {
+            // Assert that input contains a task description for the ToDo task.
+            assert inputs.length > 1 : "Specify the task description!";
             return new AddTaskCommand(new ToDo(inputs[1]));
         } else if (command.equalsIgnoreCase("deadline")) {
-            return new AddTaskCommand(new Deadline(inputs[1], inputs[2]));
+            String[] details = inputs[1].split("/by ");
+            // Assert that the task description and the deadline are provided.
+            assert details.length == 2 : "Specify the task description or deadline (/by)!";
+            return new AddTaskCommand(new Deadline(details[0], details[1]));
         } else if (command.equalsIgnoreCase("event")) {
-            return new AddTaskCommand(new Events(inputs[1], inputs[2], inputs[3]));
+            // Assert that the task description, start and end date are provided.
+            String[] details = inputs[1].split("/from | /to ");
+            assert details.length == 3 : "Specify the task description, start (/from) and end date (/to)!";
+            return new AddTaskCommand(new Events(details[0], details[1], details[2]));
         } else if (command.equalsIgnoreCase("mark")) {
+            // Assert that a task number is provided to be marked.
+            assert inputs.length > 1 : "Specify the index of the task to be marked!";
             return new MarkCommand(Integer.parseInt(inputs[1]));
         } else if (command.equalsIgnoreCase("unmark")) {
+            // Assert that a task number is provided to be unmarked.
+            assert inputs.length > 1 : "Specify the index of the task to be unmarked!";
             return new UnmarkCommand(Integer.parseInt(inputs[1]));
         } else if (command.equalsIgnoreCase("delete")) {
+            // Assert that a task number is provided to be deleted.
+            assert inputs.length > 1 : "Specify the index of the task to be deleted!";
             return new DeleteCommand(Integer.parseInt(inputs[1]));
         } else if (command.equalsIgnoreCase("date")) {
+            // Assert that a date is provided.
+            assert inputs.length > 1 : "Specify the date you wish to check!";
             return new DateCommand(inputs[1]);
         } else if (command.equalsIgnoreCase("find")) {
+            // Assert that a keyword is provided to find tasks with that keyword.
+            assert inputs.length > 1 : "Specify the keyword you wish to find!";
             return new FindCommand(inputs[1]);
         } else {
             return new UnknownCommand();

--- a/src/main/java/tudee/storage/Storage.java
+++ b/src/main/java/tudee/storage/Storage.java
@@ -49,6 +49,9 @@ public class Storage {
             while (sc.hasNextLine()) {
                 String currentLine = sc.nextLine();
                 String[] data = currentLine.split(" \\| ");
+
+                // Assert that the data array has the expected length.
+                assert data.length >= 3 : "Format is incorrect. You should have at least 3 segments.";
                 Task currentTask;
                 try {
                     switch (data[0]) {
@@ -56,9 +59,13 @@ public class Storage {
                         currentTask = new ToDo(data[2]);
                         break;
                     case "D":
+                        // Assert that Deadline has 4 segments.
+                        assert data.length == 4: "Deadline must have 4 segments";
                         currentTask = new Deadline(data[2], data[3]);
                         break;
                     case "E":
+                        // Assert that Events has 5 segments.
+                        assert data.length == 5: "Events must have 5 segments";
                         currentTask = new Events(data[2], data[3], data[4]);
                         break;
                     default:

--- a/src/main/java/tudee/task/Deadline.java
+++ b/src/main/java/tudee/task/Deadline.java
@@ -2,6 +2,9 @@ package tudee.task;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+import tudee.TudeeException;
 
 /**
  * Represents a Deadline task.
@@ -20,9 +23,13 @@ public class Deadline extends Task {
      * @param taskString The task description.
      * @param deadline The deadline date for the task, in the format yyyy-MM-dd.
      */
-    public Deadline(String taskString, String deadline) {
+    public Deadline(String taskString, String deadline) throws TudeeException {
         super(taskString);
-        this.deadline = LocalDate.parse(deadline);
+        try {
+            this.deadline = LocalDate.parse(deadline);
+        } catch (DateTimeParseException e) {
+            throw new TudeeException("Invalid date format. Please use yyyy-MM-dd.");
+        }
     }
 
     /**

--- a/src/main/java/tudee/task/Events.java
+++ b/src/main/java/tudee/task/Events.java
@@ -2,6 +2,9 @@ package tudee.task;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+import tudee.TudeeException;
 
 /**
  * Represents a Events task.
@@ -24,10 +27,14 @@ public class Events extends Task {
      * @param start The start date for the task, in the format yyyy-MM-dd.
      * @param end The end date for the task, in the format yyyy-MM-dd.
      */
-    public Events(String taskString, String start, String end) {
+    public Events(String taskString, String start, String end) throws TudeeException {
         super(taskString);
-        this.start = LocalDate.parse(start);
-        this.end = LocalDate.parse(end);
+        try {
+            this.start = LocalDate.parse(start);
+            this.end = LocalDate.parse(end);
+        } catch (DateTimeParseException e) {
+            throw new TudeeException("Invalid date format. Please use yyyy-MM-dd.");
+        }
     }
 
     /**

--- a/src/main/java/tudee/task/TaskList.java
+++ b/src/main/java/tudee/task/TaskList.java
@@ -17,6 +17,8 @@ public class TaskList {
      */
     public TaskList(List<Task> taskList) {
         this.tasks = taskList;
+        // Assert that the list is initalised correctly.
+        assert tasks != null : "Task list should not be null";
     }
 
     /**
@@ -24,6 +26,8 @@ public class TaskList {
      */
     public TaskList() {
         this.tasks = new ArrayList<>();
+        // Assert that the list is initalised correctly.
+        assert tasks != null : "Task list should be initalised as an empty list";
     }
 
     /**
@@ -32,6 +36,8 @@ public class TaskList {
      * @param task The task to be added.
      */
     public void add(Task task) {
+        // Assert that the task being added is not null.
+        assert task != null : "Task to add should not be null";
         tasks.add(task);
     }
 
@@ -42,6 +48,8 @@ public class TaskList {
      * @return The task at the specified index.
      */
     public Task get(int index) {
+        // Assert that the index is within the valid range.
+        assert index >= 0 && index < tasks.size() : "Index out of bounds";
         return tasks.get(index);
     }
 
@@ -61,6 +69,8 @@ public class TaskList {
      * @return The deleted task.
      */
     public Task delete(int index) {
+        // Assert that the index is within the valid range.
+        assert index >= 0 && index < tasks.size() : "Index out of bounds";
         return tasks.remove(index);
     }
 

--- a/src/test/java/tudee/task/DeadlineTest.java
+++ b/src/test/java/tudee/task/DeadlineTest.java
@@ -7,12 +7,14 @@ import java.time.LocalDate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import tudee.TudeeException;
+
 class DeadlineTest {
 
     private Deadline deadline;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws TudeeException {
         deadline = new Deadline("Submit assignment", "2024-09-01");
     }
 


### PR DESCRIPTION
Add assert to Parser, TaskList, Storage and Command child classes.

We did not check whether the format of the user inputs are correct. The user may incorrectly input their commands as they are not aware of the format which leads to unnecessary errors. To fix this, add assertions. This checks if the user input for specific instructions has the correct format and does not raise unnecessary errors like IndexOutOfBoundsException.

Add try-catch for DateTimeParseException in Deadline and Events class.

It is not clear to the user which datetime format to use. There are many different datetime formats such as MM/DD/YYYY or DD/MM/YYY. Therefore, standardising the format to YYYY-MM-DD would make the chatbot easier to use.